### PR TITLE
Working with .io domains

### DIFF
--- a/lib/Net/Domain/ExpireDate.pm
+++ b/lib/Net/Domain/ExpireDate.pm
@@ -311,6 +311,9 @@ sub expdate_int_cno {
     # [whois.ua]			status:     OK-UNTIL 20121122000000
     } elsif ($whois =~ m|status:\s+OK-UNTIL (\d{4})(\d{2})(\d{2})\d{6}|s) {
         $rulenum = 7.5; $Y = $1; $m = $2; $d = $3;
+    # [whois.nic.io]        Expiry : 2017-01-25
+    } elsif ($whois =~ m/Expiry : (\d{4})-(\d{2})-(\d{2})/s) {
+        $rulenum = 7.6; $Y = $1; $m = $2; $d = $3;
     }
 
     unless ($rulenum) {

--- a/t/01.t
+++ b/t/01.t
@@ -10,7 +10,7 @@ use Net::Domain::ExpireDate;
 use POSIX;
 setlocale( &POSIX::LC_TIME, "en_US.UTF-8" );
 
-BEGIN { plan tests => 70 };
+BEGIN { plan tests => 71 };
 
 ok(1); # If we made it this far, we're ok.
 
@@ -73,6 +73,7 @@ is( expdate_fmt("\nexpires:      September  5 2012\n"), '2012-09-05' );
 is( expdate_fmt("\nDomain Expiration Date:29-Apr-2013 17:53:03 UTC\n"), '2013-04-29' );
 
 is( expdate_fmt("\nstatus:     OK-UNTIL 20130104013013\n"), '2013-01-04' );
+is( expdate_fmt("\nExpiry : 2017-01-25\n"), '2017-01-25' );
 
 print ".ru tests\n";
 is( expdate_fmt("\nstate:   Delegated till 2003.10.01\nstate:   RIPN NCC check completed OK\n", 'ru'), '2003-10-01' );


### PR DESCRIPTION
Before:

```
$ perl -Ilib -MNet::Domain::ExpireDate -E 'say expire_date("c9.io")'
Can't recognise expiration date format: Domain : c9.io
Status : Live
Expiry : 2017-01-25

NS 1   : ns-925.awsdns-51.net
NS 2   : ns-1617.awsdns-10.co.uk
NS 3   : ns-1298.awsdns-34.org
NS 4   : ns-158.awsdns-19.com

Owner  : Arends, Rik
Owner  : Ajax.org
Owner  : Keizersgracht 241
Owner  : Amsterdam
Owner  : NH
Owner  : Netherlands
```

After:

```
$ perl -Ilib -MNet::Domain::ExpireDate -E 'say expire_date("c9.io")'
Wed Jan 25 00:00:00 2017
```
